### PR TITLE
fix: latest datavzrd wrapper, ci updates, multiple samples for baseline and/or changed

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -11,7 +11,7 @@ jobs:
   title-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,17 @@ on:
 jobs:
   Formatting:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
       - name: Formatting
         uses: github/super-linter@v7
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
   Formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Formatting
-        uses: github/super-linter@v5
+        uses: github/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
@@ -23,9 +23,9 @@ jobs:
   Linting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Lint workflow
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
@@ -37,17 +37,17 @@ jobs:
       - Linting
       - Formatting
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Test workflow
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile
         args: "--use-conda --show-failed-logs --cores 3 --conda-cleanup-pkgs cache"
 
     - name: Test report
-      uses: snakemake/snakemake-github-action@v1
+      uses: snakemake/snakemake-github-action@v2
       with:
         directory: .test
         snakefile: workflow/Snakefile

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           # this assumes that you have created a personal access token

--- a/.test/config/config.yaml
+++ b/.test/config/config.yaml
@@ -22,8 +22,10 @@ gfold:
       # combinations, as available from the kallisto output (and as usually
       # specified in the units.tsv). Fold changes are computed by comparing
       # the value of `changed` against the value of `baseline`. 
-      baseline: "A-1"
-      changed: "B-1"
+      baseline:
+        - "A-1"
+      changed:
+        - "B-1"
   # only absolute values of gfold_0_01 greater than this value will be
   # considered differentially expressed for downstream analysis
   gfold_0_01_cutoff: "0.01"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![GitHub actions status](https://github.com/dlaehnemann/rna-seq-conservative-fold-change-without-replicates/workflows/Tests/badge.svg?branch=main)](https://github.com/dlaehnemann/rna-seq-conservative-fold-change-without-replicates/actions?query=branch%3Amain+workflow%3ATests)
 
 
-A Snakemake workflow for `to determine conservative fold changes between transcriptomic samples when no biological replicates are available `
+A Snakemake workflow for to determine conservative fold changes between transcriptomic samples when no biological replicates are available.
+It uses [GFOLD](https://zhanglab.tongji.edu.cn/softwares/GFOLD/index.html) for conservatively estimating the fold changes.
 
 
 ## Usage
@@ -12,3 +13,6 @@ A Snakemake workflow for `to determine conservative fold changes between transcr
 The usage of this workflow is described in the [Snakemake Workflow Catalog](https://snakemake.github.io/snakemake-workflow-catalog/?usage=dlaehnemann%2Frna-seq-conservative-fold-change-without-replicates).
 
 If you use this workflow in a paper, don't forget to give credits to the authors by citing the URL of this (original) repository and its DOI (see above).
+And please also cite the [GFOLD paper](https://doi.org/10.1093/bioinformatics/bts515), as this is the main tool used here:
+
+Jianxing Feng, Clifford A. Meyer, Qian Wang, Jun S. Liu, X. Shirley Liu, Yong Zhang, GFOLD: a generalized fold change for ranking differentially expressed genes from RNA-seq data, Bioinformatics, Volume 28, Issue 21, November 2012, Pages 2782–2788, https://doi.org/10.1093/bioinformatics/bts515

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,12 +21,15 @@ gfold:
   spia_db: "resources/spia-db.rds"
   contrasts:
     # Contrast names can be chose arbitrarily, we recommend descriptive names.
-    B-1_vs_A-1:
+    B-1_vs_A-1_C-1:
       # `baseline` and `changed` need to specify existing "{sample}-{unit}"
       # combinations, as available from the kallisto output (and as usually
-      # specified in the units.tsv). Fold changes are computed by comparing
-      # the value of `changed` against the value of `baseline`. 
-      baseline: "A-1"
+      # specified in the units.tsv). Each can contain a comma-separated list
+      # of multiple {sample}-{unit} combinations, wherever replicates are
+      # available.
+      # Fold changes are computed by comparing the value of `changed` samples
+      # against the value of `baseline` samples. 
+      baseline: "A-1,C-1"
       changed: "B-1"
   # only absolute values of gfold_0_01 greater than this value will be
   # considered differentially expressed for downstream analysis

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,8 +29,11 @@ gfold:
       # available.
       # Fold changes are computed by comparing the value of `changed` samples
       # against the value of `baseline` samples. 
-      baseline: "A-1,C-1"
-      changed: "B-1"
+      baseline:
+        - "A-1"
+        - "C-1"
+      changed:
+        - "B-1"
   # only absolute values of gfold_0_01 greater than this value will be
   # considered differentially expressed for downstream analysis
   gfold_0_01_cutoff: 1.0

--- a/workflow/resources/datavzrd/gfold_template.yaml
+++ b/workflow/resources/datavzrd/gfold_template.yaml
@@ -13,7 +13,7 @@ views:
   gfold_table:
     dataset: gfold_table
     desc: |
-        ?f"Conservative fold change estimates for the contrast of {wildcards.sample_changed}-{wildcards.unit_changed} vs. {wildcards.sample_baseline}-{wildcards.unit_baseline}."
+        ?f"Conservative fold change estimates for the contrast {wildcards.contrast}."
     page-size: 25
     render-table:
       columns:

--- a/workflow/resources/datavzrd/gfold_template.yaml
+++ b/workflow/resources/datavzrd/gfold_template.yaml
@@ -1,6 +1,6 @@
 __use_yte__: true
 
-name: ?f"Conservative fold change estimates for the contrast of {wildcards.sample_changed}-{wildcards.unit_changed} vs. {wildcards.sample_baseline}-{wildcards.unit_baseline}."
+name: ?f"Conservative fold change estimates for the contrast {wildcards.contrast}"
 
 datasets:
   gfold_table:

--- a/workflow/resources/datavzrd/gfold_template.yaml
+++ b/workflow/resources/datavzrd/gfold_template.yaml
@@ -1,9 +1,14 @@
+__use_yte__: true
+
 name: ?f"Conservative fold change estimates for the contrast of {wildcards.sample_changed}-{wildcards.unit_changed} vs. {wildcards.sample_baseline}-{wildcards.unit_baseline}."
+
 datasets:
   gfold_table:
     path: ?input.gfold_table
     separator: "\t"
+
 default-view: gfold_table
+
 views:
   gfold_table:
     dataset: gfold_table

--- a/workflow/resources/datavzrd/gseapy_template.yaml
+++ b/workflow/resources/datavzrd/gseapy_template.yaml
@@ -1,3 +1,5 @@
+__use_yte__: true
+
 name: ?f"Enrichment of {wildcards.enrichr_library} for {wildcards.sample_changed}-{wildcards.unit_changed} compared to {wildcards.sample_baseline}-{wildcards.unit_baseline}"
 
 datasets:

--- a/workflow/resources/datavzrd/gseapy_template.yaml
+++ b/workflow/resources/datavzrd/gseapy_template.yaml
@@ -1,6 +1,6 @@
 __use_yte__: true
 
-name: ?f"Enrichment of {wildcards.enrichr_library} for {wildcards.sample_changed}-{wildcards.unit_changed} compared to {wildcards.sample_baseline}-{wildcards.unit_baseline}"
+name: ?f"Enrichment of {wildcards.enrichr_library} for the contrast {wildcards.contrast}"
 
 datasets:
   enrichment:

--- a/workflow/resources/datavzrd/spia_template.yaml
+++ b/workflow/resources/datavzrd/spia_template.yaml
@@ -1,6 +1,6 @@
 __use_yte__: true
 
-name: ?f"spia pathway impact analysis for contrast {wildcards.sample_changed}-{wildcards.unit_changed}_vs_{wildcards.sample_baseline}-{wildcards.unit_baseline}"
+name: ?f"spia pathway impact analysis for the contrast {wildcards.contrast}"
 
 datasets:
   spia_table:
@@ -9,7 +9,7 @@ datasets:
 
 default-view: spia_table
 
-views:
+kkkkviews:
   spia_table:
     dataset: spia_table
     desc: |

--- a/workflow/resources/datavzrd/spia_template.yaml
+++ b/workflow/resources/datavzrd/spia_template.yaml
@@ -13,7 +13,7 @@ kkkkviews:
   spia_table:
     dataset: spia_table
     desc: |
-      ?f"spia pathway impact analysis for contrast {wildcards.sample_changed}-{wildcards.unit_changed}_vs_{wildcards.sample_baseline}-{wildcards.unit_baseline}"
+      ?f"spia pathway impact analysis for the contrast {wildcards.contrast}."
     page-size: 25
     render-table:
       columns:

--- a/workflow/resources/datavzrd/spia_template.yaml
+++ b/workflow/resources/datavzrd/spia_template.yaml
@@ -9,7 +9,7 @@ datasets:
 
 default-view: spia_table
 
-kkkkviews:
+views:
   spia_table:
     dataset: spia_table
     desc: |

--- a/workflow/resources/datavzrd/spia_template.yaml
+++ b/workflow/resources/datavzrd/spia_template.yaml
@@ -1,9 +1,14 @@
+__use_yte__: true
+
 name: ?f"spia pathway impact analysis for contrast {wildcards.sample_changed}-{wildcards.unit_changed}_vs_{wildcards.sample_baseline}-{wildcards.unit_baseline}"
+
 datasets:
   spia_table:
     path: ?input.spia_table
     separator: "\t"
+
 default-view: spia_table
+
 views:
   spia_table:
     dataset: spia_table

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -6,25 +6,24 @@ import yaml
 
 def final_output(wildcards):
     final_output = []
-    for c in config["gfold"]["contrasts"]:
-        contrast = config["gfold"]["contrasts"][c]
+    for contrast in config["gfold"]["contrasts"]:
         final_output.extend(
             [
-                f"results/gfold/{contrast['changed']}_vs_{contrast['baseline']}.tsv",
-                f"results/datavzrd-reports/gfold/{contrast['changed']}_vs_{contrast['baseline']}",
+                f"results/gfold/{contrast}.tsv",
+                f"results/datavzrd-reports/gfold/{contrast}",
             ]
         )
         if config["enrichment"]["spia"]["activate_gfold"]:
             final_output.extend(
                 [
-                    f"results/datavzrd-reports/spia/{contrast['changed']}_vs_{contrast['baseline']}",
+                    f"results/datavzrd-reports/spia/{contrast}",
                 ]
             )
         if config["enrichment"]["gseapy"]["activate_gfold"]:
             final_output.extend(
                 expand(
                     "results/datavzrd/gseapy/{contrast}/{enrichr_library}",
-                    contrast=f"{contrast['changed']}_vs_{contrast['baseline']}",
+                    contrast=contrast,
                     enrichr_library=config["enrichment"]["enrichr_libraries"],
                 )
             )

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -38,6 +38,7 @@ rule spia_datavzrd:
                 "enrichment": "pathway",
             },
         ),
+        config="results/datavzrd/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.yaml",
     log:
         "logs/datavzrd-reports/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.log",
     params:
@@ -83,5 +84,6 @@ use rule spia_datavzrd as gseapy_datavzrd with:
                 "enrichment": "gene set",
             },
         ),
+        config="resources/datavzrd/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.yaml",
     log:
         "logs/datavzrd-reports/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.{enrichr_library}.log",

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -18,23 +18,9 @@ rule spia:
         "../scripts/spia.R"
 
 
-rule render_datavzrd_config_spia:
-    input:
-        template=workflow.source_path("../resources/datavzrd/spia_template.yaml"),
-        spia_table="results/spia/tables/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.tsv",
-    output:
-        "results/datavzrd/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.yaml",
-    params:
-        pathway_db=config["enrichment"]["spia"]["pathway_database"],
-    log:
-        "logs/datavzrd-render/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.yte_rendering.log",
-    template_engine:
-        "yte"
-
-
 rule spia_datavzrd:
     input:
-        config="results/datavzrd/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.yaml",
+        config=workflow.source_path("../resources/datavzrd/spia_template.yaml"),
         # files required for rendering the given configs
         spia_table="results/spia/tables/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.tsv",
     output:
@@ -54,8 +40,10 @@ rule spia_datavzrd:
         ),
     log:
         "logs/datavzrd-reports/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.log",
+    params:
+        pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
-        "v3.3.6/utils/datavzrd"
+        "v5.9.0/utils/datavzrd"
 
 
 rule gseapy:
@@ -77,21 +65,9 @@ rule gseapy:
         "../scripts/gsea.py"
 
 
-rule render_gseapy_datavzrd_config:
-    input:
-        template=workflow.source_path("../resources/datavzrd/gseapy_template.yaml"),
-        enrichment="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
-    output:
-        "resources/datavzrd/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.yaml",
-    log:
-        "logs/datavzrd-render/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.log",
-    template_engine:
-        "yte"
-
-
 use rule spia_datavzrd as gseapy_datavzrd with:
     input:
-        config="resources/datavzrd/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.yaml",
+        config=workflow.source_path("../resources/datavzrd/gseapy_template.yaml"),
         table="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
     output:
         report(

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -1,18 +1,18 @@
 rule spia:
     input:
-        filtered="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.cleaned_and_sorted.tsv",
-        all_tested_annotated="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.all_tested_annotated.tsv",
+        filtered="results/gfold/{contrast}.cleaned_and_sorted.tsv",
+        all_tested_annotated="results/gfold/{contrast}.all_tested_annotated.tsv",
         spia_db=get_spia_db,
     output:
-        table="results/spia/tables/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.tsv",
-        plots="results/spia/plots/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_perturbation_plots.pdf",
+        table="results/spia/tables/{contrast}.spia_pathways.tsv",
+        plots="results/spia/plots/{contrast}.spia_perturbation_plots.pdf",
     params:
         bioc_species_pkg=bioc_species_pkg,
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     conda:
         enrichment_env
     log:
-        "logs/enrichment/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.log",
+        "logs/enrichment/spia/{contrast}.spia_pathways.log",
     threads: 32
     script:
         "../scripts/spia.R"
@@ -22,11 +22,11 @@ rule spia_datavzrd:
     input:
         config=workflow.source_path("../resources/datavzrd/spia_template.yaml"),
         # files required for rendering the given configs
-        spia_table="results/spia/tables/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.tsv",
+        spia_table="results/spia/tables/{contrast}.spia_pathways.tsv",
     output:
         report(
             directory(
-                "results/datavzrd-reports/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}"
+                "results/datavzrd-reports/spia/{contrast}"
             ),
             htmlindex="index.html",
             caption="../report/spia_table.rst",
@@ -34,13 +34,13 @@ rule spia_datavzrd:
             subcategory="spia",
             patterns=["index.html"],
             labels={
-                "contrast": "{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}",
+                "contrast": "{contrast}",
                 "enrichment": "pathway",
             },
         ),
-        config="results/datavzrd/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.spia_pathways.yaml",
+        config="results/datavzrd/spia/{contrast}.spia_pathways.yaml",
     log:
-        "logs/datavzrd-reports/spia/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.log",
+        "logs/datavzrd-reports/spia/{contrast}.log",
     params:
         pathway_db=config["enrichment"]["spia"]["pathway_database"],
     wrapper:
@@ -49,14 +49,14 @@ rule spia_datavzrd:
 
 rule gseapy:
     input:
-        filtered="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.cleaned_and_sorted.tsv",
-        unfiltered="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.all_tested_annotated.tsv",
+        filtered="results/gfold/{contrast}.cleaned_and_sorted.tsv",
+        unfiltered="results/gfold/{contrast}.all_tested_annotated.tsv",
     output:
-        tsv="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
-        dotplot_top_n_genes="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.top_n_genes.dotplot.pdf",
-        barplot_top_n_genes="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.top_n_genes.barplot.pdf",
+        tsv="results/gseapy/{contrast}/{enrichr_library}.tsv",
+        dotplot_top_n_genes="results/gseapy/{contrast}/{enrichr_library}.top_n_genes.dotplot.pdf",
+        barplot_top_n_genes="results/gseapy/{contrast}/{enrichr_library}.top_n_genes.barplot.pdf",
     log:
-        "logs/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.log",
+        "logs/gseapy/{contrast}/{enrichr_library}.log",
     params:
         species=get_gseapy_species_name(config["resources"]["ref"]["species"]),
         number_of_top_genes=config["enrichment"]["gseapy"].get("top_n", 5),
@@ -69,21 +69,21 @@ rule gseapy:
 use rule spia_datavzrd as gseapy_datavzrd with:
     input:
         config=workflow.source_path("../resources/datavzrd/gseapy_template.yaml"),
-        enrichment="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
+        enrichment="results/gseapy/{contrast}/{enrichr_library}.tsv",
     output:
         report(
             directory(
-                "results/datavzrd/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}"
+                "results/datavzrd/gseapy/{contrast}/{enrichr_library}"
             ),
             htmlindex="index.html",
             category="Enrichment analysis",
             subcategory="gseapy: {enrichr_library}",
             caption="../report/gseapy.rst",
             labels={
-                "contrast": "{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}",
+                "contrast": "{contrast}",
                 "enrichment": "gene set",
             },
         ),
-        config="resources/datavzrd/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.yaml",
+        config="resources/datavzrd/gseapy/{contrast}/{enrichr_library}.yaml",
     log:
-        "logs/datavzrd-reports/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.{enrichr_library}.log",
+        "logs/datavzrd-reports/gseapy/{contrast}.{enrichr_library}.log",

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -25,9 +25,7 @@ rule spia_datavzrd:
         spia_table="results/spia/tables/{contrast}.spia_pathways.tsv",
     output:
         report(
-            directory(
-                "results/datavzrd-reports/spia/{contrast}"
-            ),
+            directory("results/datavzrd-reports/spia/{contrast}"),
             htmlindex="index.html",
             caption="../report/spia_table.rst",
             category="Enrichment analysis",
@@ -72,9 +70,7 @@ use rule spia_datavzrd as gseapy_datavzrd with:
         enrichment="results/gseapy/{contrast}/{enrichr_library}.tsv",
     output:
         report(
-            directory(
-                "results/datavzrd/gseapy/{contrast}/{enrichr_library}"
-            ),
+            directory("results/datavzrd/gseapy/{contrast}/{enrichr_library}"),
             htmlindex="index.html",
             category="Enrichment analysis",
             subcategory="gseapy: {enrichr_library}",

--- a/workflow/rules/enrichment.smk
+++ b/workflow/rules/enrichment.smk
@@ -68,7 +68,7 @@ rule gseapy:
 use rule spia_datavzrd as gseapy_datavzrd with:
     input:
         config=workflow.source_path("../resources/datavzrd/gseapy_template.yaml"),
-        table="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
+        enrichment="results/gseapy/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}/{enrichr_library}.tsv",
     output:
         report(
             directory(

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -39,7 +39,7 @@ rule gfold:
         ext=lambda wc, input: path.splitext(input.baseline[0])[1],
         changed=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.changed]),
     resources:
-        mem_mb = lambda wc, input: 400 * input.size_mb
+        mem_mb = 10000
     shell:
         "( gfold diff "
         "    -s1 {params.baseline} "

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -15,12 +15,12 @@ rule kallisto_quant_to_gfold_input:
 rule gfold:
     input:
         baseline=lambda wc: expand(
-            "results/gfold_input/{sample_unit}.tsv",
+            "results/gfold_input/{sample_unit_baseline}.tsv",
             sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/baseline").split(","),
         ),
         changed=lambda wc: expand(
-            "results/gfold_input/{sample_unit}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/baseline").split(","),
+            "results/gfold_input/{sample_unit_changed}.tsv",
+            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/changed").split(","),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -16,11 +16,15 @@ rule gfold:
     input:
         baseline=expand(
             "results/gfold_input/{sample_unit_baseline}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{contrast}/baseline"),
+            sample_unit_baseline=lookup(
+                within=config, dpath="gfold/contrasts/{contrast}/baseline"
+            ),
         ),
         changed=expand(
             "results/gfold_input/{sample_unit_changed}.tsv",
-            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{contrast}/changed"),
+            sample_unit_changed=lookup(
+                within=config, dpath="gfold/contrasts/{contrast}/changed"
+            ),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",
@@ -29,7 +33,9 @@ rule gfold:
     conda:
         "../envs/gfold.yaml"
     params:
-        baseline=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.baseline]),
+        baseline=lambda wc, input: ",".join(
+            [path.splitext(b)[0] for b in input.baseline]
+        ),
         ext=lambda wc, input: path.splitext(input.baseline[0])[1],
         changed=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.changed]),
     shell:
@@ -66,16 +72,12 @@ rule gfold_datavzrd:
         gfold_table="results/gfold/{contrast}.cleaned_and_sorted.tsv",
     output:
         report(
-            directory(
-                "results/datavzrd-reports/gfold/{contrast}"
-            ),
+            directory("results/datavzrd-reports/gfold/{contrast}"),
             htmlindex="index.html",
             caption="../report/gfold_table.rst",
             category="gfold",
             patterns=["index.html"],
-            labels={
-                "contrast": "{contrast}"
-            },
+            labels={"contrast": "{contrast}"},
         ),
         config="results/datavzrd/gfold/{contrast}.yaml",
     log:

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -53,21 +53,9 @@ rule clean_and_sort_gfold:
         "../scripts/clean_and_sort_gfold.R"
 
 
-rule render_datavzrd_config_gfold:
-    input:
-        template=workflow.source_path("../resources/datavzrd/gfold_template.yaml"),
-        gfold_table="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.cleaned_and_sorted.tsv",
-    output:
-        "results/datavzrd/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.yaml",
-    log:
-        "logs/datavzrd/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.yte_rendering.log",
-    template_engine:
-        "yte"
-
-
 rule gfold_datavzrd:
     input:
-        config="results/datavzrd/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.yaml",
+        config=workflow.source_path("../resources/datavzrd/gfold_template.yaml"),
         # files required for rendering the given configs
         gfold_table="results/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.cleaned_and_sorted.tsv",
     output:
@@ -86,4 +74,4 @@ rule gfold_datavzrd:
     log:
         "logs/datavzrd-reports/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.log",
     wrapper:
-        "v2.12.0/utils/datavzrd"
+        "v5.9.0/utils/datavzrd"

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -71,6 +71,7 @@ rule gfold_datavzrd:
                 "contrast": "{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}"
             },
         ),
+        config="results/datavzrd/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.yaml",
     log:
         "logs/datavzrd-reports/gfold/{sample_changed}-{unit_changed}_vs_{sample_baseline}-{unit_baseline}.log",
     wrapper:

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -16,11 +16,11 @@ rule gfold:
     input:
         baseline=lambda wc: expand(
             "results/gfold_input/{sample_unit}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.constrast}/baseline").split(","),
+            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/baseline").split(","),
         ),
         changed=lambda wc: expand(
             "results/gfold_input/{sample_unit}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.constrast}/baseline").split(","),
+            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/baseline").split(","),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -16,11 +16,11 @@ rule gfold:
     input:
         baseline=lambda wc: expand(
             "results/gfold_input/{sample_unit_baseline}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath=f"gfold/contrasts/{wc.contrast}/baseline").split(","),
+            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{contrast}/baseline").split(","),
         ),
         changed=lambda wc: expand(
             "results/gfold_input/{sample_unit_changed}.tsv",
-            sample_unit_changed=lookup(within=config, dpath=f"gfold/contrasts/{wc.contrast}/changed").split(","),
+            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{contrast}/changed").split(","),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -39,7 +39,7 @@ rule gfold:
         ext=lambda wc, input: path.splitext(input.baseline[0])[1],
         changed=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.changed]),
     resources:
-        mem_mb = 10000
+        mem_mb=10000,
     shell:
         "( gfold diff "
         "    -s1 {params.baseline} "

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -16,11 +16,11 @@ rule gfold:
     input:
         baseline=lambda wc: expand(
             "results/gfold_input/{sample_unit_baseline}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/baseline").split(","),
+            sample_unit_baseline=lookup(within=config, dpath=f"gfold/contrasts/{wc.contrast}/baseline").split(","),
         ),
         changed=lambda wc: expand(
             "results/gfold_input/{sample_unit_changed}.tsv",
-            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{wc.contrast}/changed").split(","),
+            sample_unit_changed=lookup(within=config, dpath=f"gfold/contrasts/{wc.contrast}/changed").split(","),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -39,7 +39,7 @@ rule gfold:
         ext=lambda wc, input: path.splitext(input.baseline[0])[1],
         changed=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.changed]),
     resources:
-        mem_mb = lambda wc, input: 500 * input.size_mb
+        mem_mb = lambda wc, input: 400 * input.size_mb
     shell:
         "( gfold diff "
         "    -s1 {params.baseline} "

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -14,13 +14,13 @@ rule kallisto_quant_to_gfold_input:
 
 rule gfold:
     input:
-        baseline=lambda wc: expand(
+        baseline=expand(
             "results/gfold_input/{sample_unit_baseline}.tsv",
-            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{contrast}/baseline").split(","),
+            sample_unit_baseline=lookup(within=config, dpath="gfold/contrasts/{contrast}/baseline"),
         ),
-        changed=lambda wc: expand(
+        changed=expand(
             "results/gfold_input/{sample_unit_changed}.tsv",
-            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{contrast}/changed").split(","),
+            sample_unit_changed=lookup(within=config, dpath="gfold/contrasts/{contrast}/changed"),
         ),
     output:
         gfold="results/gfold/{contrast}.tsv",

--- a/workflow/rules/gfold.smk
+++ b/workflow/rules/gfold.smk
@@ -38,6 +38,8 @@ rule gfold:
         ),
         ext=lambda wc, input: path.splitext(input.baseline[0])[1],
         changed=lambda wc, input: ",".join([path.splitext(b)[0] for b in input.changed]),
+    resources:
+        mem_mb = lambda wc, input: 500 * input.size_mb
     shell:
         "( gfold diff "
         "    -s1 {params.baseline} "

--- a/workflow/scripts/gsea.py
+++ b/workflow/scripts/gsea.py
@@ -1,30 +1,52 @@
 import sys
+
 sys.stderr = open(snakemake.log[0], "w")
 
 import pandas as pd
 import gseapy as gp
 
-background = pd.read_csv(snakemake.input.unfiltered, sep="\t").loc[:, "gene_symbol"].drop_duplicates()
+background = (
+    pd.read_csv(snakemake.input.unfiltered, sep="\t")
+    .loc[:, "gene_symbol"]
+    .drop_duplicates()
+)
 
-gfold_change = pd.read_csv(snakemake.input.filtered, sep="\t").loc[:, "gene_symbol"].drop_duplicates()
+gfold_change = (
+    pd.read_csv(snakemake.input.filtered, sep="\t")
+    .loc[:, "gene_symbol"]
+    .drop_duplicates()
+)
 
 if snakemake.wildcards.enrichr_library == "MSigDB_Hallmark_2020":
+
     def linkout_func(term):
         return f"https://www.gsea-msigdb.org/gsea/msigdb/cards/HALLMARK_{term.upper().replace(' ', '_')}"
-elif snakemake.wildcards.enrichr_library in ("GO_Biological_Process_2020", "GO_Molecular_Function_2021", "GO_Cellular_Component_2021"):
+
+elif snakemake.wildcards.enrichr_library in (
+    "GO_Biological_Process_2020",
+    "GO_Molecular_Function_2021",
+    "GO_Cellular_Component_2021",
+):
+
     def linkout_func(term):
         goid = term.split(" ")[-1].strip("()")
         return f"https://www.ebi.ac.uk/QuickGO/term/{goid}"
+
 else:
+
     def linkout_func(term):
         return f"https://www.google.com/search?q={term}"
 
 
 if len(gfold_change) <= 1:
     # enrichment does only work with at least 2 genes
-    pd.DataFrame(columns=["term", "linkout", "p-value", "FDR", "odds ratio", "genes"]).to_csv(snakemake.output[0], sep='\t', index=False)
+    pd.DataFrame(
+        columns=["term", "linkout", "p-value", "FDR", "odds ratio", "genes"]
+    ).to_csv(snakemake.output[0], sep="\t", index=False)
 else:
-    gene_set = gp.parser.download_library(snakemake.wildcards.enrichr_library, snakemake.params.species)
+    gene_set = gp.parser.download_library(
+        snakemake.wildcards.enrichr_library, snakemake.params.species
+    )
 
     enrichment = gp.enrich(
         gene_list=gfold_change,
@@ -37,39 +59,35 @@ else:
     dotplot = gp.dotplot(
         enrichment.results,
         column="Adjusted P-value",
-        x='Gene_set', # set x axis, so you could do a multi-sample/library comparsion
+        x="Gene_set",  # set x axis, so you could do a multi-sample/library comparsion
         size=10,
         top_term=top_n,
-        figsize=(16,top_n+2),
+        figsize=(16, top_n + 2),
         title=snakemake.wildcards.enrichr_library,
-        cmap='viridis',
-        xticklabels_rot=45, # rotate xtick labels
-        show_ring=True, # set to False to revmove outer ring
-        marker='o',
+        cmap="viridis",
+        xticklabels_rot=45,  # rotate xtick labels
+        show_ring=True,  # set to False to revmove outer ring
+        marker="o",
     ).get_figure()
 
     dotplot.tight_layout()
 
-    dotplot.savefig(
-        fname = snakemake.output["dotplot_top_n_genes"]
-    )
+    dotplot.savefig(fname=snakemake.output["dotplot_top_n_genes"])
 
     barplot = gp.barplot(
         enrichment.results,
         column="Adjusted P-value",
-        group='Gene_set', # set group, so you could do a multi-sample/library comparsion
+        group="Gene_set",  # set group, so you could do a multi-sample/library comparsion
         size=10,
         top_term=top_n,
-        figsize=(18,top_n+2),
+        figsize=(18, top_n + 2),
         title=snakemake.wildcards.enrichr_library,
-        cmap='Dark2',
+        cmap="Dark2",
     ).get_figure()
 
     barplot.tight_layout()
 
-    barplot.savefig(
-        fname = snakemake.output["barplot_top_n_genes"]
-    )
+    barplot.savefig(fname=snakemake.output["barplot_top_n_genes"])
 
     results = enrichment.results.sort_values("P-value")
     results.drop(columns="Gene_set", inplace=True)
@@ -82,4 +100,4 @@ else:
 
     results.insert(1, "linkout", results["term"].map(linkout_func))
 
-    results.to_csv(snakemake.output["tsv"], sep='\t', index=False)
+    results.to_csv(snakemake.output["tsv"], sep="\t", index=False)


### PR DESCRIPTION
This pull request ended up bundling a coupe of things:

* updating the datavzrd wrapper to the latest version (all the features, template rendering included)
* allowing for multiple samples in both the baseline and changed in any comparison configured in the config.yaml
* updating the continuous integration GitHub Actions to their latest versions and adjusting the configurations as necessary -- format checking was previously broken